### PR TITLE
add default empty value for baseuri

### DIFF
--- a/plugins/rest-plugin/src/main/java/ru/sbtqa/tag/api/properties/ApiConfiguration.java
+++ b/plugins/rest-plugin/src/main/java/ru/sbtqa/tag/api/properties/ApiConfiguration.java
@@ -7,6 +7,7 @@ import org.aeonbits.owner.Config.Sources;
 public interface ApiConfiguration extends Config {
 
     @Key("api.baseURI")
+    @DefaultValue("")
     String getBaseURI();
 
     @Key("api.endpoint.package")

--- a/plugins/rest-plugin/src/main/java/ru/sbtqa/tag/api/utils/PathUtils.java
+++ b/plugins/rest-plugin/src/main/java/ru/sbtqa/tag/api/utils/PathUtils.java
@@ -10,9 +10,13 @@ public class PathUtils {
     private PathUtils() {}
 
     public static String unite(String left, String right) {
-        left = left.replaceAll(SLASHES_ON_END_REGEX, EMPTY_LINE);
-        right = right.replaceAll(SLASHES_ON_START_REGEX, EMPTY_LINE);
+        if (left.isEmpty()) {
+            return right;
+        } else {
+            left = left.replaceAll(SLASHES_ON_END_REGEX, EMPTY_LINE);
+            right = right.replaceAll(SLASHES_ON_START_REGEX, EMPTY_LINE);
 
-        return left + SLASH + right;
+            return left + SLASH + right;
+        }
     }
 }


### PR DESCRIPTION
Для того чтобы можно было задавать полный урл в EndpointEntry

```
@Endpoint(method = Rest.GET, path = "https://atlassian.stash.ru/rest/api/latest/projects/${projectName}/repos/${repositoryName}", title = "Stash")
public class StashEntry extends EndpointEntry {

    @Query(name = "projectName")
    String projectName = Stash.getValue("projectName");

    @Query(name = "repositoryName")
    String repositoryName = Stash.getValue("repositoryName");
    }
}
```